### PR TITLE
use the right prefix for test, so avocado can discover

### DIFF
--- a/tests/sanity1.py
+++ b/tests/sanity1.py
@@ -32,7 +32,7 @@ class SanityCheck1(module_framework.AvocadoTest):
     :avocado: enable
     """
 
-    def smoke_test(self):
+    def test_smoke(self):
         self.start()
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect(('localhost', self.getConfig()['service']['port']))


### PR DESCRIPTION
Avocado expects for tests to have prefix "test".