### PR TITLE
add metadata support with download_url RFE (should not break backward compatibility)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: doc
 	docker build --tag=$(IMAGE_REPOSITORY) -f Dockerfile.rendered .
 
 test: build
-	cd tests; MODULE=docker DOCKERFILE="../Dockerfile.rendered" URL="docker=$(IMAGE_REPOSITORY)" mtf *.py
+	MODULE=docker DOCKERFILE="../Dockerfile.rendered" URL="docker=$(IMAGE_REPOSITORY)" make -C tests test
 
 doc: dg
 	mkdir -p ./root/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,2 @@
+test:
+	mtf --setup --metadata

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -1,0 +1,13 @@
+# for more info see: https://github.com/fedora-modularity/meta-test-family/blob/devel/mtf/metadata/README.md
+# metadata document with comments: https://github.com/fedora-modularity/meta-test-family/blob/devel/mtf/metadata/examples/general-component/tests/metadata.yaml
+document: test-metadata
+subtype: general
+download_urls:
+    generated.py: "https://raw.githubusercontent.com/container-images/memcached/master/tests/generated.py"
+    sanity.py: "https://raw.githubusercontent.com/container-images/memcached/master/tests/sanity1.py"
+enable_lint: True
+import_tests:
+    - "*.py"
+tag_filters:
+    - docker,sanity
+    - optional


### PR DESCRIPTION
This PR is safe to merge, download_urls metadata key is not implemented in actual version, so it is ignored