### PR TITLE
fix mtf issues when run tests (missing generated)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test_mtf test_conu
 
 test_mtf:
+	mtf-generator
 	mtf --setup --metadata
 
 test_conu:

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -3,11 +3,11 @@
 document: test-metadata
 subtype: general
 download_urls:
-    generated.py: "https://raw.githubusercontent.com/container-images/memcached/master/tests/generated.py"
     sanity.py: "https://raw.githubusercontent.com/container-images/memcached/master/tests/sanity1.py"
 enable_lint: True
 import_tests:
-    - "*.py"
+    - "sanity.py"
+    - "generated.py"
 tag_filters:
     - docker,sanity
     - optional


### PR DESCRIPTION
* there is conu test in same directory as mtf tests, and in metadata.yaml there were ``*.py`` caused first issue
* pregenrated `generated.py` is not aviable anymore on that location
* have to call ``mtf-generator``, to have ``generated.py`` available